### PR TITLE
Fix getExtraFieldWrapperAttributes missing

### DIFF
--- a/src/Forms/Cluster.php
+++ b/src/Forms/Cluster.php
@@ -17,6 +17,7 @@ class Cluster extends Component
     use CanBeAutofocused;
     use CanBeMarkedAsRequired;
     use CanBeValidated;
+    use Concerns\HasExtraFieldWrapperAttributes;
     use HasHelperText;
     use HasHint;
     use HasName;

--- a/src/Forms/Concerns/HasExtraFieldWrapperAttributes.php
+++ b/src/Forms/Concerns/HasExtraFieldWrapperAttributes.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Guava\FilamentClusters\Forms\Concerns;
+
+use Closure;
+use Illuminate\View\ComponentAttributeBag;
+
+/**
+ * Class copied from from here:
+ * https://github.com/filamentphp/filament/blob/v3.2.80/packages/forms/src/Components/Concerns/HasExtraFieldWrapperAttributes.php
+ *
+ * See more here:
+ * https://github.com/GuavaCZ/filament-clusters/pull/11
+ */
+trait HasExtraFieldWrapperAttributes
+{
+    /**
+     * @var array<array<mixed> | Closure>
+     */
+    protected array $extraFieldWrapperAttributes = [];
+
+    /**
+     * @param  array<mixed> | Closure  $attributes
+     */
+    public function extraFieldWrapperAttributes(array | Closure $attributes, bool $merge = false): static
+    {
+        if ($merge) {
+            $this->extraFieldWrapperAttributes[] = $attributes;
+        } else {
+            $this->extraFieldWrapperAttributes = [$attributes];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getExtraFieldWrapperAttributes(): array
+    {
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraFieldWrapperAttributes as $extraFieldWrapperAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraFieldWrapperAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
+    }
+
+    public function getExtraFieldWrapperAttributesBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraFieldWrapperAttributes());
+    }
+}


### PR DESCRIPTION
Filament v3.2.80 added extra field wrapper attributes in https://github.com/filamentphp/filament/pull/12782

The next commit broke this plugin by only including the new trait in `Field`, but not in `Component`
https://github.com/filamentphp/filament/commit/98df2fffb4f602bd4387422f8e6ec49059cd6415

As it is difficult to conditionally include traits, my proposal is to copy the new trait from Filament for now.

Another solution would be to require `"filament/filament": "^3.2.80"` but that would break some compatibility.